### PR TITLE
Add support for specify routes to cf-butler using http or https

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -16,35 +16,29 @@ A sample repository exists for your perusal [here](https://github.com/cf-toolsui
 
 ### Minimum required keys
 
-At a minimum you should supply values for the following keys
+At a minimum you should supply values for the `cf.butlers` map of butler routes via one of the following methods
 
-* `cf.butlers` -  a map of cf-butler routes
+#### Properties
+```
+cf.butlers.pws=cf-butler-grateful-mouse.cfapps.io
+cf.butlers.pcfone=cf-butler-active-tasmaniandevil.apps.pcfone.io
+```
 
-    For example
-
-    properties
-    ```
-    cf.butlers.pws=cf-butler-grateful-mouse.cfapps.io
-    cf.butlers.pcfone=cf-butler-active-tasmaniandevil.apps.pcfone.io
-    ```
-
-    yaml
-    ```
-    cf:
-      butlers:
-        pws: cf-butler-grateful-mouse.cfapps.io
-        pcfone: cf-butler-active-tasmaniandevil.apps.pcfone.io
-    ```
-    > Each key is an alias for a foundation and each value is the route to an application instance of cf-butler deployed on that foundation
+#### application.yml
+```yaml
+cf:
+  butlers:
+    pws: cf-butler-grateful-mouse.cfapps.io
+    pcfone: cf-butler-active-tasmaniandevil.apps.pcfone.io
+```
+Each key is an alias for a foundation and each value is the route to an application instance of cf-butler deployed on that foundation. If you don't include a protocol, it'll default to `https`.
 
 ### General configuration notes
 
-If you copied and appended a suffix to the original `application.yml` then you would set `spring.profiles.active` to be that suffix
-
-E.g., if you had a configuration file named `application-pws.yml`
+If you copied and appended a suffix to the original `application.yml` then you would set `spring-boot.run.profiles` to be that suffix. For example if you had a configuration file named `application-pws.yml`:
 
 ```
 ./mvnw spring-boot:run -Dspring-boot.run.profiles=pws
 ```
 
-> Consult the [samples](../samples) directory for examples.
+Consult the [samples](../samples) directory for additional examples.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,7 +4,7 @@
 
 Make a copy of then edit the contents of the `application.yml` file located in `src/main/resources`.  A best practice is to append a suffix representing the target deployment environment (e.g., `application-pws.yml`, `application-pcfone.yml`). You will need to provide administrator credentials to Apps Manager for the foundation if you want the butler to keep your entire foundation tidy.
 
-> You really should not bundle configuration with the application. To take some of the sting away, you might consider externalizing and/or [encrypting](https://blog.novatec-gmbh.de/encrypted-properties-spring/) this configuration.
+> You really should not bundle configuration with the application. To take some of the sting away, you might consider externalizing and/or [encrypting](https://docs.spring.io/spring-cloud-config/docs/current/reference/html/#_encryption_and_decryption) this configuration.
 
 ### Managing external configuration
 

--- a/docs/RUN.md
+++ b/docs/RUN.md
@@ -2,19 +2,25 @@
 
 ## How to Run with Maven
 
-```
+```shell
 ./mvnw spring-boot:run -Dspring-boot.run.profiles={target_foundation_profile}
 ```
-where `{target_foundation_profile}` is something like `pws` or `pcfone`
+where `{target_foundation_profile}` is something like `dev`, `pws` or `pcfone`.
 
-> You'll need to manually stop to the application with `Ctrl+C`
+You'll need to manually stop to the application with `Ctrl+C`
 
-Alternatively, if you intend to setup [cf-hoover-ui](https://github.com/cf-toolsuite/cf-hoover-ui), for a local development environment deployment then, you must first:
+### Running with Hoover-UI
+If you intend to optionally setup [cf-hoover-ui](https://github.com/cf-toolsuite/cf-hoover-ui) for a local development, then you must first launch a standalone instance of [Eureka server](https://cloud.spring.io/spring-cloud-netflix/multi/multi_spring-cloud-eureka-server.html) for the hoover-ui to be able to find the hoover server.
 
-* Launch a standalone instance of [Eureka server](https://cloud.spring.io/spring-cloud-netflix/multi/multi_spring-cloud-eureka-server.html)
-
-Set an additional property before launching `cf-hoover`
+Enable cloud discovery before launching `cf-hoover` via the command line or application config:
 
 ```
--Dspring.cloud.discovery.enabled=true
+./mvnw spring-boot:run -Dspring-boot.run.profiles=pws -Dspring.cloud.discovery.enabled=true
+```
+
+or via application.yml
+```yaml
+spring:
+  discovery:
+    enabled: true
 ```

--- a/src/main/java/io/pivotal/cfapp/client/DemographicsClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/DemographicsClient.java
@@ -41,7 +41,7 @@ public class DemographicsClient {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         return
 			butlers
-				.flatMap(b -> obtainDemographics(b.getKey(), "https://" + b.getValue()))
+				.flatMap(b -> obtainDemographics(b.getKey(), b.getValue()))
 				.collect(Collectors.toSet())
                 .map(dl -> Demographics
                             .builder()

--- a/src/main/java/io/pivotal/cfapp/client/OrganizationsClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/OrganizationsClient.java
@@ -32,7 +32,7 @@ public class OrganizationsClient {
     public Mono<List<Organization>> assembleOrganizations() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<Organization> organizations =
-            butlers.flatMap(b -> obtainOrganizations("https://" + b.getValue())
+            butlers.flatMap(b -> obtainOrganizations(b.getValue())
                                     .flatMapMany(lo -> Flux.fromIterable(lo))
                                     .map(o -> Organization.from(o).foundation(b.getKey()).build()));
         return organizations.collectList();

--- a/src/main/java/io/pivotal/cfapp/client/SnapshotClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/SnapshotClient.java
@@ -57,7 +57,7 @@ public class SnapshotClient {
     public Mono<List<AppDetail>> assembleApplicationDetail() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<AppDetail> detail =
-            butlers.flatMap(b -> obtainSnapshotDetail("https://" + b.getValue())
+            butlers.flatMap(b -> obtainSnapshotDetail(b.getValue())
                                     .flatMapMany(sd -> Flux.fromIterable(sd.getApplications()))
                                     .map(ad -> AppDetail.from(ad).foundation(b.getKey()).build()));
         return detail.collectList();
@@ -66,7 +66,7 @@ public class SnapshotClient {
     public Mono<List<ServiceInstanceDetail>> assembleServiceInstanceDetail() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<ServiceInstanceDetail> detail =
-            butlers.flatMap(b -> obtainSnapshotDetail("https://" + b.getValue())
+            butlers.flatMap(b -> obtainSnapshotDetail(b.getValue())
                                     .flatMapMany(sd -> Flux.fromIterable(sd.getServiceInstances()))
                                     .map(ad -> ServiceInstanceDetail.from(ad).foundation(b.getKey()).build()));
         return detail.collectList();
@@ -75,7 +75,7 @@ public class SnapshotClient {
     public Mono<List<AppRelationship>> assembleApplicationRelationships() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<AppRelationship> relations =
-            butlers.flatMap(b -> obtainSnapshotDetail("https://" + b.getValue())
+            butlers.flatMap(b -> obtainSnapshotDetail(b.getValue())
                                     .flatMapMany(sd -> Flux.fromIterable(sd.getApplicationRelationships()))
                                     .map(ad -> AppRelationship.from(ad).foundation(b.getKey()).build()));
         return relations.collectList();
@@ -137,7 +137,7 @@ public class SnapshotClient {
     public Mono<Set<String>> assembleUserAccounts() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<String> accounts =
-            butlers.flatMap(b -> obtainSnapshotDetail("https://" + b.getValue())
+            butlers.flatMap(b -> obtainSnapshotDetail(b.getValue())
                                     .flatMapMany(sd -> Flux.fromIterable(sd.getUserAccounts())));
         return accounts.collect(Collectors.toCollection(TreeSet::new));
     }
@@ -145,7 +145,7 @@ public class SnapshotClient {
     public Mono<Set<String>> assembleServiceAccounts() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<String> accounts =
-            butlers.flatMap(b -> obtainSnapshotDetail("https://" + b.getValue())
+            butlers.flatMap(b -> obtainSnapshotDetail(b.getValue())
                                     .flatMapMany(sd -> Flux.fromIterable(sd.getServiceAccounts())));
         return accounts.collect(Collectors.toCollection(TreeSet::new));
     }
@@ -153,7 +153,7 @@ public class SnapshotClient {
     protected Mono<ApplicationCounts> assembleApplicationCounts() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         return butlers
-                .flatMap(b -> obtainSnapshotSummary("https://" + b.getValue()))
+                .flatMap(b -> obtainSnapshotSummary(b.getValue()))
                                 .map(sd -> sd.getApplicationCounts())
                                 .collectList()
                                 .map(acl -> ApplicationCounts.aggregate(acl));
@@ -162,7 +162,7 @@ public class SnapshotClient {
     protected Mono<ServiceInstanceCounts> assembleServiceInstanceCounts() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         return butlers
-                .flatMap(b -> obtainSnapshotSummary("https://" + b.getValue()))
+                .flatMap(b -> obtainSnapshotSummary(b.getValue()))
                                 .map(sd -> sd.getServiceInstanceCounts())
                                 .collectList()
                                 .map(acl -> ServiceInstanceCounts.aggregate(acl));

--- a/src/main/java/io/pivotal/cfapp/client/SpaceUsersClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/SpaceUsersClient.java
@@ -36,7 +36,7 @@ public class SpaceUsersClient {
 	public Flux<SpaceUsers> findAll() {
 		Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
 		return
-			butlers.flatMap(b -> obtainSpaceUsers("https://" + b.getValue())
+			butlers.flatMap(b -> obtainSpaceUsers(b.getValue())
 									.map(su -> SpaceUsers.from(su).foundation(b.getKey()).build()));
 	}
 

--- a/src/main/java/io/pivotal/cfapp/client/SpacesClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/SpacesClient.java
@@ -32,7 +32,7 @@ public class SpacesClient {
     public Mono<List<Space>> assembleSpaces() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<Space> spaces =
-            butlers.flatMap(b -> obtainSpaces("https://" + b.getValue())
+            butlers.flatMap(b -> obtainSpaces(b.getValue())
                                     .flatMapMany(ls -> Flux.fromIterable(ls))
                                     .map(s -> Space.from(s).foundation(b.getKey()).build()));
         return spaces.collectList();

--- a/src/main/java/io/pivotal/cfapp/client/SpringApplicationClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/SpringApplicationClient.java
@@ -37,7 +37,7 @@ public class SpringApplicationClient {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         return
             butlers
-                .flatMap(b -> obtainSpringApplicationDetail("https://" + b.getValue())
+                .flatMap(b -> obtainSpringApplicationDetail(b.getValue())
                 .map(ad -> JavaAppDetail.from(ad).foundation(b.getKey()).build()))
                 .collectList();
     }
@@ -63,7 +63,7 @@ public class SpringApplicationClient {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         return
             butlers
-                .flatMap(b -> obtainSpringApplicationDependencyFrequency("https://" + b.getValue()))
+                .flatMap(b -> obtainSpringApplicationDependencyFrequency(b.getValue()))
                 .flatMapIterable(Map::entrySet)
                 .collect(Collectors.toMap(
                     Map.Entry::getKey,

--- a/src/main/java/io/pivotal/cfapp/client/TimeKeeperClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/TimeKeeperClient.java
@@ -35,7 +35,7 @@ public class TimeKeeperClient {
     public Mono<Set<TimeKeeper>> assembleDateTimeCollection() {
         Flux<Map.Entry<String, String>> butlers = Flux.fromIterable(settings.getButlers().entrySet());
         Flux<TimeKeeper> result =
-            butlers.flatMap(b -> obtainDateTimeCollected("https://" + b.getValue())
+            butlers.flatMap(b -> obtainDateTimeCollected(b.getValue())
                                     .map(dtc -> TimeKeeper.builder().foundation(b.getKey()).collectionDateTime(dtc).build()));
         return result.collectList().map(l -> Set.copyOf(l));
     }

--- a/src/main/java/io/pivotal/cfapp/client/UsageClient.java
+++ b/src/main/java/io/pivotal/cfapp/client/UsageClient.java
@@ -33,7 +33,7 @@ public class UsageClient {
     }
 
     protected Mono<TaskUsageReport> getTaskReport(String butlerRoute) {
-        String uri = "https://" + butlerRoute + "/accounting/tasks";
+        String uri = butlerRoute + "/accounting/tasks";
         return client
                 .get()
                     .uri(uri)
@@ -50,7 +50,7 @@ public class UsageClient {
     }
 
     protected Mono<AppUsageReport> getApplicationReport(String butlerRoute) {
-        String uri = "https://" + butlerRoute + "/accounting/applications";
+        String uri = butlerRoute + "/accounting/applications";
         return client
                 .get()
                     .uri(uri)
@@ -67,7 +67,7 @@ public class UsageClient {
     }
 
     protected Mono<ServiceUsageReport> getServiceReport(String butlerRoute) {
-        String uri = "https://" + butlerRoute + "/accounting/services";
+        String uri = butlerRoute + "/accounting/services";
         return client
                 .get()
                     .uri(uri)

--- a/src/main/java/io/pivotal/cfapp/config/HooverSettings.java
+++ b/src/main/java/io/pivotal/cfapp/config/HooverSettings.java
@@ -18,4 +18,15 @@ public class HooverSettings {
 	private boolean sslValidationSkipped;
 	private Duration timeout = Duration.ofMinutes(2);
 
+	public void setButlers(Map<String, String> butlers) {
+		butlers.replaceAll((k, v) -> butlerURL(v));
+		this.butlers = butlers;
+	}
+
+	private String butlerURL(String url) {
+		if (!url.startsWith("http")) {
+			url = "https://" + url;
+		}
+		return url;
+	}
 }


### PR DESCRIPTION
Add support for specifying cf-butler routes with optional http or https protocol. The following are now all valid cf-butler routes in the config:

- cf-butler.example.com
- https://cf-butler.example.com
- http://cf-butler.example.com

This allows cf-hoover users to specify cf-butler routes with and without the http(s) protocol which is less more flexible. Probably more importantly this allows cf-butler devs to run against local cf-butler instances that only expose http (and not https). This also reduces some duplication and string concatenation in the codebase.